### PR TITLE
Fixed bug with duplicate ARP not checking timeout

### DIFF
--- a/lib/dashed/button.rb
+++ b/lib/dashed/button.rb
@@ -37,7 +37,7 @@ module Dashed
     end
 
     def duplicate_arp?
-      last_press && (last_press - Time.now).abs < 45
+      last_press && (last_press - Time.now).abs < @timeout
     end
   end
 end


### PR DESCRIPTION
Timeout can be configured but wasn’t being utilized, 45 is same as
default for timeout constant
