### PR TITLE
Support current Dash Buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ thread.
 ## Known Issues
 
  - Buttons can not be sniffed out on some OS X machines
- - Some buttons seem to have a different version of the Amazon Dash button
    software that render them useless for this.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ thread.
 ## Known Issues
 
  - Buttons can not be sniffed out on some OS X machines
-   software that render them useless for this.
 
 ## Contributing
 

--- a/dashed.gemspec
+++ b/dashed.gemspec
@@ -6,8 +6,8 @@ require 'dashed/version'
 Gem::Specification.new do |spec|
   spec.name          = "dashed"
   spec.version       = Dashed::VERSION
-  spec.authors       = ["Justin Kenyon", "Blake Williams"]
-  spec.email         = ["kenyonj@gmail.com", "blake@blakewilliams.me"]
+  spec.authors       = ["Justin Kenyon", "Blake Williams", 'Robert Müller']
+  spec.email         = ["kenyonj@gmail.com", "blake@blakewilliams.me", 'code@brauser.io']
 
   spec.summary       = %q{Library for interacting with Amazon Dash buttons}
   spec.description   = %q{Library for interacting with Amazon Dash buttons}

--- a/exe/find_dash
+++ b/exe/find_dash
@@ -4,6 +4,11 @@ require 'pcaprub'
 require_relative '../lib/dashed/packet'
 
 interface = ARGV[0]
+DASH_PREFIX = ['74::74', '44:65']
+
+def valid_prefix? mac
+  !!DASH_PREFIX.any? { |p| mac.start_with? p }
+end
 
 if interface
   capture = PCAPRUB::Pcap.open_live(interface, 65535, true, 0)
@@ -11,7 +16,7 @@ if interface
 
   capture.each_packet do |raw_packet|
     packet = Dashed::Packet.new(raw_packet)
-    if packet.host_mac_address.start_with? "74:75"
+    if valid_prefix?(packet.host_mac_address)
       puts "Potential Amazon Dash Button #{packet.host_mac_address}"
     end
   end

--- a/lib/dashed/version.rb
+++ b/lib/dashed/version.rb
@@ -1,3 +1,3 @@
 module Dashed
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Specify prefix to allow multiple mac ranges to be recognized by find_dash.
